### PR TITLE
check if res is nil before check error

### DIFF
--- a/jsparser.go
+++ b/jsparser.go
@@ -147,6 +147,11 @@ func (j *JsonParser) parse() {
 
 					}
 
+					//if res is nil is because the json is invalid
+					if res == nil {
+						return
+					}
+
 					if res.Err != nil {
 						return
 					}


### PR DESCRIPTION
Before check if error, first if res is nil. This avoid panic if json is invalid

Fixes #1 